### PR TITLE
Adds meaningful class names and max-width to .child

### DIFF
--- a/lib/BlurHashImage.vue
+++ b/lib/BlurHashImage.vue
@@ -25,10 +25,10 @@ defineExpose({
 })
 </script>
 <template>
-  <div class="parent">
+  <div class="vue-blur-hash-parent">
     <blur-hash-canvas
       v-show="!imageLoaded"
-      class="child"
+      class="vue-blur-hash-child"
       key="canvas"
       :hash="hash"
       :width="width"
@@ -39,7 +39,7 @@ defineExpose({
       key="img"
       v-bind="$attrs"
       v-show="imageLoaded"
-      class="child"
+      class="vue-blur-hash-child"
       :width="width"
       :height="height"
       :src="src"
@@ -50,12 +50,13 @@ defineExpose({
 </template>
 
 <style scoped>
-.parent {
+.vue-blur-hash-parent {
   display: grid;
   grid-template: 1fr / 1fr;
 }
 
-.child {
+.vue-blur-hash-child {
   grid-area: 1 / 1 / 2 / 2;
+  max-width: 100%;
 }
 </style>


### PR DESCRIPTION
This commit aims to change the `.parent` and `.child` classes in order to make them more specific to the plugin. These terms are too generic and my cause conflicts with other stylesheets.

Also, `max-width: 100%;` is added to the `.child` class. This would avoid situations where the whole container is larger than the image size and the aspect ration must be preserved (a Masonry container, for example).